### PR TITLE
changed pytorch to torch on requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ scikit-image
 scikit-learn
 #dscribe
 #ase
-pytorch
+torch


### PR DESCRIPTION
colab throws the error that it's torch and not pytorch to install